### PR TITLE
Download queue changed to keep it running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ RUN install2.r --error --skipinstalled --ncpus -1 \
      shiny.i18n \
      dbplyr \
      here \
+     shinyalert \
+     future \
      && rm -rf /tmp/downloaded_packages
 
 # Create folder 

--- a/funs/download_fun.R
+++ b/funs/download_fun.R
@@ -62,8 +62,8 @@ dl_station <- function(id, time_start, time_end) {
     log_trace("Downloading measurements for AQ station. pm10 station: {lmlstation[1]}, pm25 station: {lmlstation[2]}")
     for(j in unique(lmlstation)) {
         log_trace("downloading for LML station  {j}")
-        print(lmlstation)
-        print(unique(lmlstation))
+#         print(lmlstation)
+#         print(unique(lmlstation))
         d <- download_data(j, Tstart = time_start, Tend = time_end,
                            fun = "download_data_lml",
                            conn = conn)

--- a/funs/queue_fun.R
+++ b/funs/queue_fun.R
@@ -114,7 +114,7 @@ task_q <- R6::R6Class(
                                          duplicates <- which(private$tasks$state == "duplicate")
                                          if(length(duplicates) >=1) {
                                              log_trace("running duplicates {duplicates} tasks: {private$tasks$id[duplicates]}")
-                                             print(private$tasks$id[duplicates])
+#                                              print(private$tasks$id[duplicates])
                                              for(i in duplicates) {
                                                  log_trace("running {i}")
                                                  id <- gsub(".* ", "", private$tasks$id[i])

--- a/global.R
+++ b/global.R
@@ -57,6 +57,7 @@ library(samanapir)
 library(ATdatabase)
 
 # Source functions
+library(here)
 source("funs/assign_color_stations.R")
 source("funs/assign_linetype_stations.R")
 source("funs/geoshaper_findlocations.R")
@@ -64,6 +65,10 @@ source("funs/database_fun.R")
 source("funs/queue_fun.R")
 source("funs/download_fun.R")
 source("funs/data_to_tool_fun.R")
+
+# launch queue manager
+qm_script <- here("scripts","queue_manager.R")
+system2("Rscript", qm_script, wait = FALSE)
 
 
 # Set language and date options                                             ====
@@ -185,10 +190,10 @@ source("modules/add_timevariation_daily_plot.R")
 # Source layout
 source("modules/add_tabpanels.R")
 
-# Source que display
-source("modules/view_que.R")
-
-# Create the queue
-que <- task_q$new()
-
+# # Source que display
+# source("modules/view_que.R")
+# 
+# # Create the queue
+# que <- task_q$new()
+# 
 ### THE END                                                                 ====

--- a/scripts/create_data_request.R
+++ b/scripts/create_data_request.R
@@ -1,0 +1,72 @@
+######################################################################
+# script to test download queue manager 
+######################################################################
+# This script creates 5 data request, based on a random selection of
+# existing. Each data request contains 10 stations for which a small
+# time range is requested
+######################################################################
+
+
+# Read in the necessary libraries                                           ====
+
+# Tidyverse (essential)
+library(tidyverse)
+
+# Databases (essential)
+library(RSQLite)
+library(pool)
+
+library(lubridate)
+
+# logger
+library(logger)
+log_threshold(TRACE)
+
+library(samanapir)
+library(ATdatabase)
+library(here)
+
+# set working directory to root of repo
+setwd(here::here())
+
+# source scripts
+
+source(here("funs","database_fun.R"))
+source(here("funs","queue_fun.R"))
+source(here("funs","download_fun.R"))
+source(here("scripts","test_functions.R"))
+
+# Connect with the database using pool, store data, read table              ====
+    
+fname_db <- get_database_path()
+pool <- dbPool(
+
+               drv = SQLite(),
+               dbname = fname_db
+
+)
+#sqliteSetBusyHandler(pool, 10e3)
+
+# get some testing data to create jobs, add jobs to meta database
+
+dbtables <- get_db_tables(pool)
+
+
+for(i in 1:4) {
+    job_id <- sprintf("id%010.0f", round(runif(1, 1, 2^32), digits = 0))
+    print(job_id)
+
+    dl_req <- data.frame()
+    for (i in 1:10) {
+        rnd_station <- get_rnd_station(dbtables)
+        dl_req <- bind_rows(dl_req, data.frame(station = rnd_station$station,
+                                               time_start = rnd_station$time_start,
+                                               time_end = rnd_station$time_end, row.names = NULL))
+    }
+
+    add_doc(type = "data_req", ref = job_id, doc = dl_req, conn = pool, overwrite = TRUE)
+    x <- get_doc(type = "data_req", ref = job_id, conn = pool)
+}
+
+
+poolClose(pool)

--- a/scripts/launch_queue_manager.R
+++ b/scripts/launch_queue_manager.R
@@ -1,0 +1,45 @@
+######################################################################
+# This scripts launches and monitors the que manager
+######################################################################
+######################################################################
+
+# Read in the necessary libraries                                           ====
+
+# Tidyverse (essential)
+library(tidyverse)
+
+# Databases (essential)
+library(RSQLite)
+library(pool)
+
+library(lubridate)
+
+# logger
+library(logger)
+log_threshold(TRACE)
+
+library(samanapir)
+library(ATdatabase)
+library(here)
+
+# set working directory to root of repo
+setwd(here::here())
+
+# source scripts
+
+source(here("funs","database_fun.R"))
+source(here("funs","queue_fun.R"))
+source(here("funs","download_fun.R"))
+source(here("scripts","test_functions.R"))
+
+qm_script <- here("scripts","queue_manager.R")
+
+system2("Rscript", qm_script, wait = FALSE)
+
+for(i in 1:5) {
+    source(here("scripts", "create_data_request.R"))
+}
+
+while(TRUE) {
+    Sys.sleep(3600)
+}

--- a/scripts/launch_queue_manager.R
+++ b/scripts/launch_queue_manager.R
@@ -33,7 +33,6 @@ source(here("funs","download_fun.R"))
 source(here("scripts","test_functions.R"))
 
 qm_script <- here("scripts","queue_manager.R")
-
 system2("Rscript", qm_script, wait = FALSE)
 
 for(i in 1:5) {

--- a/scripts/queue_manager.R
+++ b/scripts/queue_manager.R
@@ -77,8 +77,8 @@ list_doc <- function(type, conn) {
         for (i in 1:nrow(j)) {
 
             qid <- que$push(dl_station, list(j$station[i],
-                                             j$time_start[i],
-                                             j$time_end[i]), 
+                                             as_datetime(j$time_start[i]),
+                                             as_datetime(j$time_end[i])), 
                             id = j$station[i])
             log_trace("pushed job {qid} to the queue")
             que$poll()
@@ -87,8 +87,15 @@ list_doc <- function(type, conn) {
         time_spent <- system.time(
 
                                   while(nrow(que$list_tasks()) >4) {
-                                      while(!is.null(que$pop())) {
-                                          que$pop()
+                                      repeat{
+                                          res <- que$pop()
+                                          if(!is.null(res)) {
+                                              if(!is.null(res$error)) {
+                                                  log_warn("ERROR dl_station:\n {res$error}")
+                                              }
+                                          } else {
+                                              break
+                                          }
                                       }
                                       Sys.sleep(3)
                                   }

--- a/scripts/queue_manager.R
+++ b/scripts/queue_manager.R
@@ -1,0 +1,102 @@
+######################################################################
+# script to test download queue manager 
+######################################################################
+# This script runs the queue manager in a idle while loop. The queue
+# manager takes a data request from the database and starts the
+# downloadprocesses to get data from the API. To put data request in
+# the datbase, see script create_data_request.R
+######################################################################
+
+
+# Read in the necessary libraries                                           ====
+
+# Tidyverse (essential)
+library(tidyverse)
+
+# Databases (essential)
+library(RSQLite)
+library(pool)
+
+library(lubridate)
+
+# logger
+library(logger)
+log_threshold(TRACE)
+
+library(samanapir)
+library(ATdatabase)
+library(here)
+
+# set working directory to root of repo
+setwd(here::here())
+
+# source scripts
+
+source(here("funs","database_fun.R"))
+source(here("funs","queue_fun.R"))
+source(here("funs","download_fun.R"))
+source(here("scripts","test_functions.R"))
+
+# Connect with the database using pool, store data, read table              ====
+    
+fname_db <- get_database_path()
+pool <- dbPool(
+
+               drv = SQLite(),
+               dbname = fname_db
+
+)
+
+list_doc <- function(type, conn) {
+
+    qry <- glue::glue_sql("SELECT ref FROM meta WHERE type={type};", 
+                          .con = conn)
+    res <- dbGetQuery(conn, qry)
+    return(res$ref)
+
+}
+
+
+    que <- task_q$new()
+    # get single job
+
+    while(TRUE) {
+
+        joblist <- list_doc(type = "data_req", conn = pool)
+        if(length(joblist) == 0) {
+            log_trace("queue_man: no data requests")
+            Sys.sleep(5)
+            next
+        }
+        job_id <- joblist[1]
+        j <- get_doc(type = "data_req", ref = job_id, conn = pool)
+
+        # create queue, run jobs, wait until finished, collect stats
+
+
+        for (i in 1:nrow(j)) {
+
+            qid <- que$push(dl_station, list(j$station[i],
+                                             j$time_start[i],
+                                             j$time_end[i]), 
+                            id = j$station[i])
+            log_trace("pushed job {qid} to the queue")
+            que$poll()
+        }
+
+        time_spent <- system.time(
+
+                                  while(nrow(que$list_tasks()) >4) {
+                                      while(!is.null(que$pop())) {
+                                          que$pop()
+                                      }
+                                      Sys.sleep(3)
+                                  }
+        )
+
+        j_done <- list(j, data.frame(sec = c(time_spent)))
+        remove_doc(type = "data_req", ref = job_id, conn = pool)
+        add_doc(type = "data_req_done", ref = job_id, doc = j_done, conn = pool)
+    }
+
+

--- a/server.R
+++ b/server.R
@@ -70,4 +70,12 @@ shinyServer(function(global, input, output, session) {
 
   view_que_server("view_que", que)
 
+  # keep queue running
+  a <- observe({
+      invalidateLater(3e3, NULL) # 10 seconds
+      log_trace("server: poll queue")
+      que$poll()
+      
+  }, suspended = TRUE)
+
 })


### PR DESCRIPTION
I fixed #132. The queue is now a separate process within the app, independent of the R Shiny process. This means that the queue keeps running even after users close their browsers.  This separate process is now started from the app, but we can run it completely independent from the app, as it is a separate script.
The queue now uses data requests which are stored in the meta table. Each data request contains the data (stations + time range) which was input with the 'get external data' button. After a request is completed, statistics of the request are stored to the meta table, so we can later figure out how we can calculate download times.
I also changed the dockerfile and added missing libs.